### PR TITLE
update twitter screen name

### DIFF
--- a/app/scripts/text.js
+++ b/app/scripts/text.js
@@ -302,8 +302,8 @@
           title: 'Hardware Hacking for JavaScript Developers',
           speakers: [
             {
-              url:  'http://twitter.com/girliemac',
-              name: '@girliemac'
+              url:  'http://twitter.com/girlie_mac',
+              name: '@girlie_mac'
             }
           ]
         },


### PR DESCRIPTION
スケジュールページの girlie_mac さんのアカウントがサブ垢になっていたので、スピーカーページのアカウントと統一しておきました。