### PR TITLE
Splitting the presentation of tokutoku393

### DIFF
--- a/2018/schedule.html
+++ b/2018/schedule.html
@@ -1824,8 +1824,12 @@
       </div>
       
         <div class="session-content">
-          <p class="session-time">Nov. 24, 10:30 - 15:00, Room D</p>
-          <h2 class="session-title">Workshop: Building hardware</h2>
+          <p class="session-time">Nov. 24, 10:30 - 11:45, Room D</p>
+          <h2 class="session-title">Workshop: JavaScriptでハードウェア開発やってみよう</h2>
+          
+          <div class="session-summary">
+            <p>このワークショップは日本語で行われます。<br>JavaScriptで開発できるマイコンボード「obniz」を使って、ハードウェアとWebの連携を試してみるハンズオンです！<br>手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。</p>
+          </div>
           
         </div>
         
@@ -1835,6 +1839,30 @@
 </div>
 
 <div class="overlay" data-key="interactive-4-2">
+  <div class="overlay-content">
+
+    <button class="overlay-button">
+      <svg xmlns="http://www.w3.org/2000/svg" class="overlay-icon"><use xlink:href="#close"></use></svg>
+    </button>
+
+    <div class="session">
+      
+        <div class="session-content">
+          <p class="session-time">Nov. 24, 13:00 - 15:00, Room D</p>
+          <h2 class="session-title">Workshop: Node-REDで楽しくIoT体験</h2>
+          
+          <div class="session-summary">
+            <p>このワークショップは日本語で行われます。<br>npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！<br>これにしたいです！遅くなりごめんなさい。</p>
+          </div>
+          
+        </div>
+        
+    </div>
+
+  </div>
+</div>
+
+<div class="overlay" data-key="interactive-4-3">
   <div class="overlay-content">
 
     <button class="overlay-button">
@@ -1923,7 +1951,7 @@
       
         <div class="session-content">
           <p class="session-time">Nov. 24, 10:30 - 11:45, Room E</p>
-          <h2 class="session-title">ワークショップ: 分散ストレージ体験</h2>
+          <h2 class="session-title">Workshop: 分散ストレージ体験</h2>
           
           <div class="session-summary">
             <p>このワークショップは日本語で行われます。<br><br>分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た<br>Node.js 版ライブラリを利用することで、私たちは DAT を使った分散ストレージを体験できます。このワークショップではツールやコードを用いた<br>DAT ストレージ作成を通じて、分散ストレージの面白さを学ぶことができます。<br><br>ワークショップのゴール：<br>・ DAT を使ってホームページを作って公開する。<br>・ その ホームページを Beaker Browser で見てやりとりする。<br>・ Node.js を使って DAT をリモートプロセスでやりとりする。</p>
@@ -2069,21 +2097,23 @@
   <td  rowspan="4"  class="confcal-entry"><a class="confcal-text" href="#interactive-2-1"><h3 class="confcal-title">NodeSchool</h3>
       <div class="confcal-byline">by <span class="confcal-person">@n0bisuke</span></div></a></td>
   <td  rowspan="4"  class="confcal-entry"><div class="confcal-text"><h3 class="confcal-title">Collaboration Space</h3></div></td>
-  <td  rowspan="3"  class="confcal-entry"><a class="confcal-text" href="#interactive-4-1"><h3 class="confcal-title">Workshop: Building hardware</h3>
+  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-4-1"><h3 class="confcal-title">Workshop: JavaScriptでハードウェア開発やってみよう</h3>
       <div class="confcal-byline">by <span class="confcal-person">Tokuyama Yuka</span></div></a></td>
-  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-1"><h3 class="confcal-title">ワークショップ: 分散ストレージ体験</h3>
+  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-1"><h3 class="confcal-title">Workshop: 分散ストレージ体験</h3>
       <div class="confcal-byline">by <span class="confcal-person">Martin Heidegger</span></div></a></td></tr>
         <tr class="confcal-slot confcal-slot-2 confcal-slot-break">
   <td   class="confcal-entry confcal-entry-break"></td>
-  <td   class="confcal-entry confcal-entry-break"></td></tr>
+  <td   colspan="2" class="confcal-entry confcal-entry-break"></td></tr>
         <tr class="confcal-slot confcal-slot-3 confcal-slot-by">
   <td   class="confcal-entry"><div class="confcal-text"><h3 class="confcal-title">Node/W3C Discussion</h3></div></td>
+  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-4-2"><h3 class="confcal-title">Workshop: Node-REDで楽しくIoT体験</h3>
+      <div class="confcal-byline">by <span class="confcal-person">@Node-RED User Group Japan</span></div></a></td>
   <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-2"><h3 class="confcal-title">Workshop: Building a Small Compiler in JavaScript</h3>
       <div class="confcal-byline">by <span class="confcal-person">Rob Howard</span></div></a></td></tr>
         <tr class="confcal-slot confcal-slot-4 confcal-slot-by">
   <td   class="confcal-entry"><a class="confcal-text" href="#interactive-1-4"><h3 class="confcal-title">Code And Learn</h3>
       <div class="confcal-byline">by <span class="confcal-person">Yuta Hiroto</span></div></a></td>
-  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-4-2"><h3 class="confcal-title">Workshop: Hands-On React</h3>
+  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-4-3"><h3 class="confcal-title">Workshop: Hands-On React</h3>
       <div class="confcal-byline">by <span class="confcal-person">Yan Fan</span></div></a></td>
   <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-3"><h3 class="confcal-title">Workshop: JavaScript TodoMVC</h3>
       <div class="confcal-byline">by <span class="confcal-person">古川 陽介</span></div></a></td></tr>

--- a/2018/schedule.html
+++ b/2018/schedule.html
@@ -1852,7 +1852,7 @@
           <h2 class="session-title">Workshop: Node-REDで楽しくIoT体験</h2>
           
           <div class="session-summary">
-            <p>このワークショップは日本語で行われます。<br>npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！<br>これにしたいです！遅くなりごめんなさい。</p>
+            <p>このワークショップは日本語で行われます。<br>npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！</p>
           </div>
           
         </div>
@@ -1951,7 +1951,7 @@
       
         <div class="session-content">
           <p class="session-time">Nov. 24, 10:30 - 11:45, Room E</p>
-          <h2 class="session-title">Workshop: 分散ストレージ体験</h2>
+          <h2 class="session-title">ワークショップ: 分散ストレージ体験</h2>
           
           <div class="session-summary">
             <p>このワークショップは日本語で行われます。<br><br>分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た<br>Node.js 版ライブラリを利用することで、私たちは DAT を使った分散ストレージを体験できます。このワークショップではツールやコードを用いた<br>DAT ストレージ作成を通じて、分散ストレージの面白さを学ぶことができます。<br><br>ワークショップのゴール：<br>・ DAT を使ってホームページを作って公開する。<br>・ その ホームページを Beaker Browser で見てやりとりする。<br>・ Node.js を使って DAT をリモートプロセスでやりとりする。</p>
@@ -2099,7 +2099,7 @@
   <td  rowspan="4"  class="confcal-entry"><div class="confcal-text"><h3 class="confcal-title">Collaboration Space</h3></div></td>
   <td   class="confcal-entry"><a class="confcal-text" href="#interactive-4-1"><h3 class="confcal-title">Workshop: JavaScriptでハードウェア開発やってみよう</h3>
       <div class="confcal-byline">by <span class="confcal-person">Tokuyama Yuka</span></div></a></td>
-  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-1"><h3 class="confcal-title">Workshop: 分散ストレージ体験</h3>
+  <td   class="confcal-entry"><a class="confcal-text" href="#interactive-5-1"><h3 class="confcal-title">ワークショップ: 分散ストレージ体験</h3>
       <div class="confcal-byline">by <span class="confcal-person">Martin Heidegger</span></div></a></td></tr>
         <tr class="confcal-slot confcal-slot-2 confcal-slot-break">
   <td   class="confcal-entry confcal-entry-break"></td>

--- a/2018/speakers.html
+++ b/2018/speakers.html
@@ -839,7 +839,7 @@
       Martin Heidegger
     </p>
     <p class="speaker-session">
-      A trillion points with Node.js<br/>Workshop: 分散ストレージ体験
+      A trillion points with Node.js<br/>ワークショップ: 分散ストレージ体験
     </p>
   </div>
 </a>
@@ -892,7 +892,7 @@
         
         <div class="session-content">
           <p class="session-time">Nov. 24, 10:30 - 11:45, Room E</p>
-          <h2 class="session-title">Workshop: 分散ストレージ体験</h2>
+          <h2 class="session-title">ワークショップ: 分散ストレージ体験</h2>
           
           <div class="session-summary">
             <p>このワークショップは日本語で行われます。<br><br>分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た<br>Node.js 版ライブラリを利用することで、私たちは DAT を使った分散ストレージを体験できます。このワークショップではツールやコードを用いた<br>DAT ストレージ作成を通じて、分散ストレージの面白さを学ぶことができます。<br><br>ワークショップのゴール：<br>・ DAT を使ってホームページを作って公開する。<br>・ その ホームページを Beaker Browser で見てやりとりする。<br>・ Node.js を使って DAT をリモートプロセスでやりとりする。</p>

--- a/2018/speakers.html
+++ b/2018/speakers.html
@@ -839,7 +839,7 @@
       Martin Heidegger
     </p>
     <p class="speaker-session">
-      A trillion points with Node.js<br/>ワークショップ: 分散ストレージ体験
+      A trillion points with Node.js<br/>Workshop: 分散ストレージ体験
     </p>
   </div>
 </a>
@@ -892,7 +892,7 @@
         
         <div class="session-content">
           <p class="session-time">Nov. 24, 10:30 - 11:45, Room E</p>
-          <h2 class="session-title">ワークショップ: 分散ストレージ体験</h2>
+          <h2 class="session-title">Workshop: 分散ストレージ体験</h2>
           
           <div class="session-summary">
             <p>このワークショップは日本語で行われます。<br><br>分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た<br>Node.js 版ライブラリを利用することで、私たちは DAT を使った分散ストレージを体験できます。このワークショップではツールやコードを用いた<br>DAT ストレージ作成を通じて、分散ストレージの面白さを学ぶことができます。<br><br>ワークショップのゴール：<br>・ DAT を使ってホームページを作って公開する。<br>・ その ホームページを Beaker Browser で見てやりとりする。<br>・ Node.js を使って DAT をリモートプロセスでやりとりする。</p>
@@ -2256,7 +2256,7 @@
       Tokuyama Yuka
     </p>
     <p class="speaker-session">
-      Workshop: Building hardware
+      Workshop: JavaScriptでハードウェア開発やってみよう
     </p>
   </div>
 </a>
@@ -2298,8 +2298,12 @@
       </div>
       
         <div class="session-content">
-          <p class="session-time">Nov. 24, 10:30 - 15:00, Room D</p>
-          <h2 class="session-title">Workshop: Building hardware</h2>
+          <p class="session-time">Nov. 24, 10:30 - 11:45, Room D</p>
+          <h2 class="session-title">Workshop: JavaScriptでハードウェア開発やってみよう</h2>
+          
+          <div class="session-summary">
+            <p>このワークショップは日本語で行われます。<br>JavaScriptで開発できるマイコンボード「obniz」を使って、ハードウェアとWebの連携を試してみるハンズオンです！<br>手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。</p>
+          </div>
           
         </div>
         

--- a/2018/src/confcal/interactive.confcal
+++ b/2018/src/confcal/interactive.confcal
@@ -61,7 +61,6 @@ at Yahoo Japan Corporation#ChIJ30G_l3iLGGARWbrLEBhHS3s
 
     このワークショップは日本語で行われます。
     npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
-    これにしたいです！遅くなりごめんなさい。
 
 15:00-17:00 Workshop: Hands-On React by yanarchy in en
 
@@ -80,7 +79,7 @@ at Yahoo Japan Corporation#ChIJ30G_l3iLGGARWbrLEBhHS3s
     and want to gain deeper understanding.
 
 [Room E]
-10:30-11:45 Workshop: 分散ストレージ体験 by leichtgewicht
+10:30-11:45 ワークショップ: 分散ストレージ体験 by leichtgewicht
 
     このワークショップは日本語で行われます。
 

--- a/2018/src/confcal/interactive.confcal
+++ b/2018/src/confcal/interactive.confcal
@@ -51,7 +51,18 @@ at Yahoo Japan Corporation#ChIJ30G_l3iLGGARWbrLEBhHS3s
 10:30-17:00 Collaboration Space in en
 
 [Room D]
-10:30-15:00 Workshop: Building hardware by tokutoku393 in en
+10:30-11:45 Workshop: JavaScriptでハードウェア開発やってみよう by tokutoku393
+
+    このワークショップは日本語で行われます。
+    JavaScriptで開発できるマイコンボード「obniz」を使って、ハードウェアとWebの連携を試してみるハンズオンです！
+    手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。
+
+13:00-15:00 Workshop: Node-REDで楽しくIoT体験 by Node-RED User Group Japan
+
+    このワークショップは日本語で行われます。
+    npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
+    これにしたいです！遅くなりごめんなさい。
+
 15:00-17:00 Workshop: Hands-On React by yanarchy in en
 
     An accelerated workshop to get your hands dirty with React. We'll cover the following topics:
@@ -69,7 +80,7 @@ at Yahoo Japan Corporation#ChIJ30G_l3iLGGARWbrLEBhHS3s
     and want to gain deeper understanding.
 
 [Room E]
-10:30-11:45 ワークショップ: 分散ストレージ体験 by leichtgewicht
+10:30-11:45 Workshop: 分散ストレージ体験 by leichtgewicht
 
     このワークショップは日本語で行われます。
 

--- a/2018/src/confcal/interactive.csv
+++ b/2018/src/confcal/interactive.csv
@@ -38,10 +38,8 @@ JavaScriptで開発できるマイコンボード「obniz」を使って、ハ�
 手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。",
 #1 by Node-RED User Group Japan - summary,Workshop: Node-REDで楽しくIoT体験,Workshop: Node-REDで楽しくIoT体験,
 #1 by Node-RED User Group Japan - description,"このワークショップは日本語で行われます。
-npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
-これにしたいです！遅くなりごめんなさい。","このワークショップは日本語で行われます。
-npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
-これにしたいです！遅くなりごめんなさい。",
+npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！","このワークショップは日本語で行われます。
+npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！",
 #1 by yanarchy - summary,Workshop: Hands-On React,,Workshop: Hands-On React
 #1 by yanarchy - description,"An accelerated workshop to get your hands dirty with React. We'll cover the following topics:
 
@@ -66,7 +64,7 @@ This workshop is best for developers who have never used React or have only used
 ・ State vs stateless components
 
 This workshop is best for developers who have never used React or have only used it a little and want to gain deeper understanding."
-#1 by leichtgewicht - summary,Workshop: 分散ストレージ体験,Workshop: 分散ストレージ体験,
+#1 by leichtgewicht - summary,ワークショップ: 分散ストレージ体験,ワークショップ: 分散ストレージ体験,
 #1 by leichtgewicht - description,"このワークショップは日本語で行われます。
 
 分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た

--- a/2018/src/confcal/interactive.csv
+++ b/2018/src/confcal/interactive.csv
@@ -30,7 +30,18 @@ This talk will cover:
 After Party - summary,After Party,,After Party
 #1 by n0bisuke - summary,NodeSchool,,NodeSchool
 Collaboration Space - summary,Collaboration Space,,Collaboration Space
-#1 by tokutoku393 - summary,Workshop: Building hardware,,Workshop: Building hardware
+#1 by tokutoku393 - summary,Workshop: JavaScriptでハードウェア開発やってみよう,Workshop: JavaScriptでハードウェア開発やってみよう,
+#1 by tokutoku393 - description,"このワークショップは日本語で行われます。
+JavaScriptで開発できるマイコンボード「obniz」を使って、ハードウェアとWebの連携を試してみるハンズオンです！
+手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。","このワークショップは日本語で行われます。
+JavaScriptで開発できるマイコンボード「obniz」を使って、ハードウェアとWebの連携を試してみるハンズオンです！
+手軽にモノを動かす体験ができるので、ハードウェア初心者の方もぜひ参加してください。",
+#1 by Node-RED User Group Japan - summary,Workshop: Node-REDで楽しくIoT体験,Workshop: Node-REDで楽しくIoT体験,
+#1 by Node-RED User Group Japan - description,"このワークショップは日本語で行われます。
+npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
+これにしたいです！遅くなりごめんなさい。","このワークショップは日本語で行われます。
+npmから手軽にインストールできるNode-REDを使って、実際にノートPCからハードウェアを制御してIoT体験します。ぜひ動かす面白さを体験してください～！ノートPCなしでも体験できるデモ機も準備する予定です。お楽しみに！
+これにしたいです！遅くなりごめんなさい。",
 #1 by yanarchy - summary,Workshop: Hands-On React,,Workshop: Hands-On React
 #1 by yanarchy - description,"An accelerated workshop to get your hands dirty with React. We'll cover the following topics:
 
@@ -55,7 +66,7 @@ This workshop is best for developers who have never used React or have only used
 ・ State vs stateless components
 
 This workshop is best for developers who have never used React or have only used it a little and want to gain deeper understanding."
-#1 by leichtgewicht - summary,ワークショップ: 分散ストレージ体験,ワークショップ: 分散ストレージ体験,
+#1 by leichtgewicht - summary,Workshop: 分散ストレージ体験,Workshop: 分散ストレージ体験,
 #1 by leichtgewicht - description,"このワークショップは日本語で行われます。
 
 分散ストレージはデータ保存やデータ利用に関するエキサイティングで新たな方法です。DAT プロジェクトのよく出来た


### PR DESCRIPTION
This splits the presentation of tokutoku393 into two:

<img width="946" alt="screen shot 2018-11-21 at 16 37 24" src="https://user-images.githubusercontent.com/914122/48826393-7dc52f80-edad-11e8-9125-ce0dcc38cdd8.png">
<img width="849" alt="screen shot 2018-11-21 at 16 45 17" src="https://user-images.githubusercontent.com/914122/48826394-7dc52f80-edad-11e8-8f7c-ac2d655a60c5.png">
<img width="839" alt="screen shot 2018-11-21 at 16 45 23" src="https://user-images.githubusercontent.com/914122/48826395-7e5dc600-edad-11e8-8e89-6c11bceb0948.png">
